### PR TITLE
Set the `dom` property to a different default

### DIFF
--- a/src/pat-sortable-table.js
+++ b/src/pat-sortable-table.js
@@ -39,7 +39,7 @@ export default Base.extend({
         }
 
         $(el).DataTable({
-            dom: '<"top"i>rt<"bottom"flp><"clear">',
+            dom: '<"top"lf>rt<"bottom"ip><"clear">',
             retrieve: true,
             pagingType: this.options.pagingType,
             pageLength: this.options.page.length,


### PR DESCRIPTION
This makes the display behave like the basic example on the datatables website.