### PR TITLE
Set the `dom` property to a different default (Part II)

### DIFF
--- a/src/pat-sortable-table.js
+++ b/src/pat-sortable-table.js
@@ -39,7 +39,7 @@ export default Base.extend({
         }
 
         $(el).DataTable({
-            dom: '<"top"lf>rt<"bottom"ip><"clear">',
+            dom: '<"data-table-top"if>rt<"data-table-bottom"lp><"data-table-clear">',
             retrieve: true,
             pagingType: this.options.pagingType,
             pageLength: this.options.page.length,


### PR DESCRIPTION
1) move the search field above the table
2) Use better (more specific) class names